### PR TITLE
Set SEND_TO_ACURITE = False

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -3,4 +3,4 @@ STATION_ID = 'KCASANFR9999'
 STATION_KEY = 'xxxxxxx'
 FREQUENCY = 30 # number of seconds to send updates
 ACURITE_HUB_IP = '52.22.110.201' # the real ip for hubapi.myacurite.com
-SEND_TO_ACURITE = True # send data to acurite, while you still can
+SEND_TO_ACURITE = False # send data to acurite, while you still can


### PR DESCRIPTION
Since there is no longer any reason to send data to Acurite.  Set the default value the FALSE in the example config.